### PR TITLE
Fix mutex initialization and setup flow

### DIFF
--- a/init_setup_table.c
+++ b/init_setup_table.c
@@ -45,19 +45,19 @@ int setup_env(t_table *table) {
 	int	i;
 
 	i = 0;
-	if(!setup_mutexes(table))
-        return 1;
+       if (setup_mutexes(table))
+               return 1;
 	while(i < table->n) {
 		setup_table(table , table->philos , i);
 		i++;
 	}
-	if (!create_threads(table, table->philos))
-	{
-		destroy_mutexes(table);
-		free(table);
-		return (1);
-	}
-	destroy_mutexes(table);
-	free(table);
-	return 0;
+       if (!create_threads(table, table->philos))
+       {
+               destroy_mutexes(table);
+               free(table);
+               return (1);
+       }
+       destroy_mutexes(table);
+       free(table);
+       return (0);
 }

--- a/main.c
+++ b/main.c
@@ -12,17 +12,17 @@
 
 #include "philo.h"
 
-
-
-int	main(int c, char **v)
+int     main(int c, char **v)
 {
-	t_table	*table;
-	if(!is_valid(c , v)) {
-		printf("Eroor : you should enter a spesific arg\n");
-		return 1;
-	}
-	table = init_shell(c ,v);
-	if(!setup_env(table))
-		return 1;
-	return (0);
+        t_table *table;
+
+        if (!is_valid(c, v))
+        {
+                printf("Eroor : you should enter a spesific arg\n");
+                return (1);
+        }
+        table = init_shell(c, v);
+        if (setup_env(table))
+                return (1);
+        return (0);
 }

--- a/setup_mutexes.c
+++ b/setup_mutexes.c
@@ -20,16 +20,16 @@ int	setup_mutexes(t_table *args)
 	args->forks = malloc(sizeof(pthread_mutex_t) * args->n);
 	if (!args->forks)
 			return 1;
-	while (i < args->n)
-	{
-		if(!pthread_mutex_init(&args->forks[i], NULL))
-			return 1;
-		i++;
-	}
-	if(!pthread_mutex_init(&args->print, NULL))
-		return 1;
-	if(!pthread_mutex_init(&args->set, NULL))
-		return 1;
+       while (i < args->n)
+       {
+               if (pthread_mutex_init(&args->forks[i], NULL))
+                       return 1;
+               i++;
+       }
+       if (pthread_mutex_init(&args->print, NULL))
+               return 1;
+       if (pthread_mutex_init(&args->set, NULL))
+               return 1;
 	return 0;
 }
 


### PR DESCRIPTION
## Summary
- Correct mutex setup to properly initialize forks and shared mutexes
- Align setup logic with standard success/error return values

## Testing
- `./philo 1 800 200 200`
- `./philo 5 800 200 200 7` *(fails: philosopher 3 dies at 1205ms)*
- `./philo 4 310 200 100`
- `./philo 5 800 200 200` *(fails: philosopher 3 dies at 6213ms)*

------
https://chatgpt.com/codex/tasks/task_e_689e21740f8c8326be7780f33999403f